### PR TITLE
Updated homepage link to have target = '_blank'

### DIFF
--- a/public/js/connection.js
+++ b/public/js/connection.js
@@ -72,6 +72,7 @@ var templateResults = function(results) {
       if (e.tagName === 'A') {
         switch (k) {
           case 'homepage':
+            e.target = '_blank';
             e.href = v;
           break;
 


### PR DESCRIPTION
When browsing search results, it's nice if users don't have to leave that particular search in order to investigate the package on NPM.