### PR TITLE
Change color of Twitter follow link

### DIFF
--- a/public/core.css
+++ b/public/core.css
@@ -269,4 +269,5 @@ section#intro {
 .twitter-follow-button {
   position:absolute;
   right: 1%;
+  color: #6DD9F9;
 }


### PR DESCRIPTION
A small thing, but I couldn't really read the anchor text in the default blue so I tweaked it.  Now it pops!

<img width="670" alt="screen shot 2015-12-07 at 1 23 24 pm" src="https://cloud.githubusercontent.com/assets/3527094/11636989/8c04341e-9ce4-11e5-9705-32f9a3ec5b2b.png">

Nice search util, btw.