### PR TITLE
Fixed minor possible crash

### DIFF
--- a/bin/rating.js
+++ b/bin/rating.js
@@ -101,7 +101,7 @@ function collect(project) {
 
 
   if (!project || project.error) {
-    console.log('FAIL', project.name);
+    console.log('FAIL', project && project.name || "UNKNOWN PROJECT");
     return;
   }
 


### PR DESCRIPTION
This line could throw an error if `project` is undefined, a check that happens in the `if` above it.