### PR TITLE
Tweak `result-container` styles

### DIFF
--- a/public/core.css
+++ b/public/core.css
@@ -143,6 +143,11 @@ textarea, input {
 #result-container {
   display: none;
   flex-grow: 1;
+  margin: 25px auto;
+  min-width: 800px;
+  max-width: 80%;
+  border-left: 1px solid #E1E7E6;
+  border-right: 1px solid #E1E7E6;
 }
 
 #result-container table.list {

--- a/public/core.css
+++ b/public/core.css
@@ -39,8 +39,20 @@ hr {
 }
 
 header {
-  padding: 25px 40px;
   background: #fff;
+}
+
+@media all and (min-width: 1400px) {
+  header {
+    margin: 0px auto;
+    width: 1400px;
+  }
+}
+
+@media all and (max-width: 1399px) {
+  header {
+    padding: 25px 40px;
+  }
 }
 
 header h1 {

--- a/public/core.css
+++ b/public/core.css
@@ -144,14 +144,12 @@ textarea, input {
   display: none;
   flex-grow: 1;
   margin: 25px auto;
-  min-width: 800px;
-  max-width: 80%;
   border-left: 1px solid #E1E7E6;
   border-right: 1px solid #E1E7E6;
 }
 
 #result-container table.list {
-  width: 100%;
+  width: 1400px;
   border-collapse: collapse;
 }
 #result-container table thead th {
@@ -339,6 +337,26 @@ body.searching #searching {
 
 body.searching #result-table {
   display: none;
+}
+
+#result-container table tbody td#score {
+  width: 105px;
+}
+
+#result-container table tbody td#name {
+  width: 60%;
+}
+
+#result-container table tbody td#version {
+  width: 120px;
+}
+
+#result-container table tbody td#author {
+  width: 10%;
+}
+
+#result-container table tbody td#update {
+  width: 120px;
 }
 
 div.score div.num {

--- a/public/core.css
+++ b/public/core.css
@@ -144,8 +144,6 @@ textarea, input {
   display: none;
   flex-grow: 1;
   margin: 25px auto;
-  border-left: 1px solid #E1E7E6;
-  border-right: 1px solid #E1E7E6;
 }
 
 #result-container table.list {

--- a/public/core.css
+++ b/public/core.css
@@ -40,19 +40,9 @@ hr {
 
 header {
   background: #fff;
-}
-
-@media all and (min-width: 1400px) {
-  header {
-    margin: 0px auto;
-    width: 1400px;
-  }
-}
-
-@media all and (max-width: 1399px) {
-  header {
-    padding: 25px 40px;
-  }
+  max-width: 1400px;
+  margin: 0 auto;
+  width: 100%;
 }
 
 header h1 {

--- a/public/core.css
+++ b/public/core.css
@@ -149,9 +149,15 @@ textarea, input {
 }
 
 #result-container table.list {
-  width: 1400px;
   border-collapse: collapse;
 }
+
+@media all and (min-width: 1400px) {
+  #result-container table.list {
+    width: 1400px;
+  }
+}
+
 #result-container table thead th {
   height: 32px;
   border-bottom: 1px solid #e1e7e6;

--- a/public/core.css
+++ b/public/core.css
@@ -350,7 +350,7 @@ body.searching #result-table {
 }
 
 #result-container table tbody td#name {
-  width: 60%;
+  width: 40%;
 }
 
 #result-container table tbody td#version {
@@ -358,7 +358,7 @@ body.searching #result-table {
 }
 
 #result-container table tbody td#author {
-  width: 10%;
+  width: 25%;
 }
 
 #result-container table tbody td#update {

--- a/public/index.html
+++ b/public/index.html
@@ -66,13 +66,13 @@
           </tbody>
           <tbody id="results">
             <tr class="result">
-              <td>
+              <td id="score">
                 <div class="badge score">
                   <img src="images/ns-badge.svg">
                   <div class="num">9.8</div>
                 </div>
               </td>
-              <td>
+              <td id="name">
                 <h2 class="name">
                   <a class="homepage" href="">Untitled Project</a>
                 </h2>
@@ -85,20 +85,20 @@
                   <li class="license">??</li>
                 </ul>
               </td>
-              <td>
+              <td id="version">
                 <span class="version">unknown</span>
               </td>
-              <td>
+              <td id="author">
                 <a class="author" href="?q=author:unknown">unknown</a>
               </td>
-              <td>
+              <td id="update">
                 <span class="timestamp">unknown</span>
               </td>
             </tr>
           </tbody>
         </table>
         <div id="searching"><img src="images/spinner.gif" /></div>
-      </section> 
+      </section>
       <section class="intro" id="intro">
         <div class="examples">
           <h3 class="semi-bold top">Example Queries:</h3>


### PR DESCRIPTION
**After** (Screenshot):
<img width="1664" alt="after_tweaks" src="https://cloud.githubusercontent.com/assets/5035902/24077302/2a86c828-0c8c-11e7-8b92-43570ce27433.png">
Before (Screenshot):
![before_styles](https://cloud.githubusercontent.com/assets/5035902/24077314/7f09f014-0c8c-11e7-866a-cadde5a8c760.png)
cc @joemccann 