### PR TITLE
[score] use scoring scale consistent with NCM instead of original npmsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ curl "http://npmsearch.com/query?q=dom&fields=name"
 * __scripts__
 * __times__
 * __version__
-* __rating__ - computed rating as per [bin/rating.js](bin/rating.js)
+* __score__ - npmsearch uses The [NodeSource Certification Process](http://npmsearch.com/about) to compute score
+* __rating__ - the original rating (computed as per [bin/rating.js](bin/rating.js)) has been deprecated, and the rating field is now `score/10`
 
 # Running your own npmsearch
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -38,8 +38,10 @@ module.exports = function(req, res) {
 
         params.fields = (params.fields || '').split(',').map(function(field) {
           field = field.trim()
+          // flag if query is for rating, not score
           if (field === 'rating') {
             field = 'score';
+            params.rating = true
           }
 
           if (field === 'modified') {
@@ -77,10 +79,15 @@ module.exports = function(req, res) {
           var l = o.hits.hits.length, hits = o.hits.hits;
           for (var i = 0; i<l; i++) {
             var fields = hits[i].fields
-            // return a rating as to not break existing clients
-            if (fields.score) {
-              fields.rating = [ fields.score / 10 ]
-              delete fields.score
+            // return a rating ando/or score appropriately
+            if (fields && fields.score && params.rating) {
+              fields.rating = [ fields.score[0] / 10 ]
+              if (fields.score.length > 1) {
+                fields.score = [ fields.score[1] ]
+              }
+              else {
+                delete fields.score
+              }
             }
 
             if (fields['times.published']) {

--- a/public/core.css
+++ b/public/core.css
@@ -271,14 +271,15 @@ table tbody td a.author {
 
 #result-container table tbody td .badge {
   background-color: lightblue;
-  width: 70px;
+  width: 90px;
   height: 30px;
-  padding: 0 10px;
   border-radius: 2px;
   align-items: center;
-  display:flex;
+  display: flex;
   color: white;
 }
+
+
 
 #result-container table tbody td.score .badge span {
   height: 100%;
@@ -294,7 +295,7 @@ table tbody td a.author {
 }
 
 #results {
-  width: 90%;
+  width: 80%;
   min-width:550px;
   margin: 0 auto;
   list-style-type: none;
@@ -366,13 +367,15 @@ body.searching #result-table {
 }
 
 div.score div.num {
-  font-size: 16px;
-  color: #ffffff;
-  font-weight: 300;
+  width: 100%;
   border-left: 1px solid rgba(0, 0, 0, 0.2);
-  padding-left: 15px;
-  margin-left: 10px;
+  text-align: center;
   line-height: 30px;
+  color: #ffffff;
+}
+
+div.score img {
+  margin: 0 7px;
 }
 
 h2.name {

--- a/public/js/bundle.js
+++ b/public/js/bundle.js
@@ -7356,7 +7356,7 @@ skateboard(function(stream) {
       var results = [];
       obj.response.docs.forEach(function(doc) {
         if (typeof doc.score === 'undefined') {
-          doc.score = 0.0;
+          doc.score = 0;
         }
 
         if (isNaN(doc.score) || typeof doc.description === 'undefined') {
@@ -7400,9 +7400,9 @@ skateboard(function(stream) {
         if (isNaN(doc.score)) {
           //return;
         } else if (doc.score >= 99.9) {
-          doc.score = '10';
+          doc.score = '100';
         } else {
-          doc.score = Number(doc.score/10).toFixed(1);
+          doc.score = doc.score;
         }
         results.push(doc);
       });
@@ -7985,8 +7985,8 @@ const ok = '#ffb726'
 const bad = '#ff6040'
 
 const scoreColors = [
-  [9.5, certified],
-  [8.6, ok],
+  [95, certified],
+  [86, ok],
   [0, bad]
 ]
 

--- a/public/js/connection.js
+++ b/public/js/connection.js
@@ -355,7 +355,7 @@ skateboard(function(stream) {
       var results = [];
       obj.response.docs.forEach(function(doc) {
         if (typeof doc.score === 'undefined') {
-          doc.score = 0.0;
+          doc.score = 0;
         }
 
         if (isNaN(doc.score) || typeof doc.description === 'undefined') {
@@ -399,9 +399,9 @@ skateboard(function(stream) {
         if (isNaN(doc.score)) {
           //return;
         } else if (doc.score >= 99.9) {
-          doc.score = '10';
+          doc.score = '100';
         } else {
-          doc.score = Number(doc.score/10).toFixed(1);
+          doc.score = doc.score;
         }
         results.push(doc);
       });

--- a/public/js/score-color.js
+++ b/public/js/score-color.js
@@ -6,8 +6,8 @@ const ok = '#ffb726'
 const bad = '#ff6040'
 
 const scoreColors = [
-  [9.5, certified],
-  [8.6, ok],
+  [95, certified],
+  [86, ok],
   [0, bad]
 ]
 


### PR DESCRIPTION
scores are out of the original 100 instead of 10.

@tmpvar PTAL